### PR TITLE
Allowedflare example

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,4 +1,5 @@
-env: ALLOWEDFLARE_EMAILS="['person@emailprovider.example']"
+env:
+    ALLOWEDFLARE_EMAILS="['person@emailprovider.example']"
     ALLOWEDFLARE_PRIVATE_DOMAIN=organization.example
     CLOUDFLARE_ACCOUNT_ID=0123456789abcdef0123456789abcdef00
     CLOUDFLARE_ZONE_ID=0123456789abcdef0123456789abcdef01

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,8 +1,8 @@
 env:
-    ALLOWEDFLARE_EMAILS="['person@emailprovider.example']"
-    ALLOWEDFLARE_PRIVATE_DOMAIN=organization.example
-    CLOUDFLARE_ACCOUNT_ID=0123456789abcdef0123456789abcdef00
-    CLOUDFLARE_ZONE_ID=0123456789abcdef0123456789abcdef01
+    ALLOWEDFLARE_EMAILS: "['person@emailprovider.example']"
+    ALLOWEDFLARE_PRIVATE_DOMAIN: organization.example
+    CLOUDFLARE_ACCOUNT_ID: 0123456789abcdef0123456789abcdef00
+    CLOUDFLARE_ZONE_ID: 0123456789abcdef0123456789abcdef01
 name: Check
 jobs:
     check:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,3 +1,7 @@
+env: ALLOWEDFLARE_EMAILS="['person@emailprovider.example']"
+    ALLOWEDFLARE_PRIVATE_DOMAIN=organization.example
+    CLOUDFLARE_ACCOUNT_ID=0123456789abcdef0123456789abcdef00
+    CLOUDFLARE_ZONE_ID=0123456789abcdef0123456789abcdef01
 name: Check
 jobs:
     check:

--- a/deploys/allowedflare/terraform/.terraform.lock.hcl
+++ b/deploys/allowedflare/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "4.26.0"
+  constraints = "4.26.0"
+  hashes = [
+    "h1:gHcFOTjdVmVW0/XW2XQ8tmhNh973126WaAuBwKlJ990=",
+    "zh:086c755d1dd7399b354f391242c9be636d95fc5b91e5a85cbf1e476607dae4dc",
+    "zh:2315c1d4a7496225d4b6421498cdfea2e459f66fd98eb0e125dfe44740fbc644",
+    "zh:258d2a34f10cff913fd73d56b3ceae863c144b45ba9f8b4c2ddaae74282d146d",
+    "zh:27fd7a3edf509079041f09fd413e157f72fbda1827e82324da384c820f366e7e",
+    "zh:65d9fd2af262463fdefbb803d310518b3e8f78a8ba20d2b0a2c63b55770f294f",
+    "zh:6987c738de0b1fec31545c67de1cda88c4c01f2b5244d7b2e26462a8a1339439",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:90806d49509f1a02f5503eb98ba0156c9ebec16587e20a0aa4143cb935ad5928",
+    "zh:ac3c2e6d5f40b56d7dfcdd6ae49803644cc6e3cc69d7c369c78c7d9f385decc2",
+    "zh:acf1177ad5b399accddfb8847134c3b8c1b226bfbc4e3acfe7698e7de61d7cfa",
+    "zh:b2991776b8846d5b819c8673879a459a17f68efb199110c43a446d6c0d6ce17c",
+    "zh:cd8c44f495f4ab370e59b0c86ff4c0cc4f8853eb4697019ec5aa2164a1c66856",
+    "zh:f100d1c9475c071a8766a6b2dfef8318e8eda878726343e7d2f59aec17373f42",
+    "zh:f678dc7995387439df5c56c86a295bda29b1f8fffdee749a3d51f231a94e252b",
+    "zh:ffce3d977269cb0a600f6b4203537f3587009e44e3ca11c4f6a82bb5fb359d0c",
+  ]
+}

--- a/deploys/allowedflare/terraform/main.py
+++ b/deploys/allowedflare/terraform/main.py
@@ -1,0 +1,65 @@
+"""Codify Allowedflare infrastructure."""
+
+from ast import literal_eval
+from os import environ
+
+from cdktf_cdktf_provider_cloudflare.access_application import AccessApplication
+from cdktf_cdktf_provider_cloudflare.access_identity_provider import AccessIdentityProvider
+from cdktf_cdktf_provider_cloudflare.access_policy import AccessPolicy, AccessPolicyInclude
+from cdktf_cdktf_provider_cloudflare.worker_route import WorkerRoute
+
+from helicopyter import HeliStack
+
+
+def synth(stack: HeliStack) -> None:
+    stack.provide('cloudflare')
+
+    # If this was a private repository, I'd probably set these variables using string literals
+    account_id = environ['CLOUDFLARE_ACCOUNT_ID']
+    emails = literal_eval(environ['ALLOWEDFLARE_EMAILS'])
+    private_domain = environ['ALLOWEDFLARE_PRIVATE_DOMAIN']
+    zone_id = environ['CLOUDFLARE_ZONE_ID']
+
+    stack.push(
+        AccessIdentityProvider,
+        'this',
+        account_id=account_id,
+        name='One-time PIN',
+        type='onetimepin',
+    )
+
+    application = stack.push(
+        AccessApplication,
+        'this',
+        domain=f'*.{private_domain}',
+        session_duration='24h',
+        skip_interstitial=True,
+    )
+
+    stack.push(
+        AccessPolicy,
+        'email-in',
+        name='email-in',
+        application_id=application.id,
+        decision='allow',
+        precedence=1,
+        include=[AccessPolicyInclude(email=emails)],
+    )
+
+    stack.push(
+        AccessPolicy,
+        'service-in',
+        name='service-in',
+        application_id=application.id,
+        decision='non_identity',
+        precedence=2,
+        include=[AccessPolicyInclude(any_valid_service_token=True)],
+    )
+
+    stack.push(
+        WorkerRoute,
+        'this',
+        pattern=f'*.{private_domain}/x/*',
+        script_name='allowedflare-proxy',
+        zone_id=zone_id,
+    )

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,6 @@
 # Build time
+cdktf-cdktf-provider-cloudflare
+cdktf-cdktf-provider-null
 ipython
 mypy
 pre-commit
@@ -13,5 +15,4 @@ yamllint
 # Runtime
 # TODO figure out how to install these from pyproject.toml
 cdktf
-cdktf-cdktf-provider-null
 typed-argument-parser

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,10 @@ attrs==23.2.0
 cattrs==23.2.3
     # via jsii
 cdktf==0.20.0
-    # via cdktf-cdktf-provider-null
+    # via
+    #   cdktf-cdktf-provider-cloudflare
+    #   cdktf-cdktf-provider-null
+cdktf-cdktf-provider-cloudflare==11.8.0
 cdktf-cdktf-provider-null==10.0.0
 certifi==2023.11.17
     # via requests
@@ -22,6 +25,7 @@ charset-normalizer==3.3.2
 constructs==10.3.0
     # via
     #   cdktf
+    #   cdktf-cdktf-provider-cloudflare
     #   cdktf-cdktf-provider-null
 cryptography==42.0.5
     # via secretstorage
@@ -58,9 +62,10 @@ jeepney==0.8.0
     # via
     #   keyring
     #   secretstorage
-jsii==1.94.0
+jsii==1.97.0
     # via
     #   cdktf
+    #   cdktf-cdktf-provider-cloudflare
     #   cdktf-cdktf-provider-null
     #   constructs
 keyring==24.3.0
@@ -160,6 +165,7 @@ typed-argument-parser==1.9.0
 typeguard==2.13.3
     # via
     #   cdktf
+    #   cdktf-cdktf-provider-cloudflare
     #   cdktf-cdktf-provider-null
     #   constructs
     #   jsii

--- a/requirements.txt
+++ b/requirements.txt
@@ -111,6 +111,7 @@ ptyprocess==0.7.0
 publication==0.0.3
     # via
     #   cdktf
+    #   cdktf-cdktf-provider-cloudflare
     #   cdktf-cdktf-provider-null
     #   constructs
     #   jsii

--- a/style.md
+++ b/style.md
@@ -1,3 +1,12 @@
+## Version control, manual review, automated checks
+Use version control, code review, and automated tests/checks for most changes. Exceptions to consider:
+
+- URLs and other environment variables https://12factor.net/config
+- Some deploys/$cona/terraform/main.tf.json files are omitted from this public repository because of
+  account-specific values. Checking in generated JSON into internal repositories is recommended.
+  Doing so keeps the files ready for commands like `terraform plan` and `terraform apply` and allows
+  `git bisect` to help solve JSON level issues (hopefully rare).
+
 ## Formatting
 ### Indent by four spaces
 This aligns with PEP-8. Consistent indentation across file types makes editor configuration easier.
@@ -8,7 +17,7 @@ A maximized gnome-terminal window on a ThinkPad X1 Carbon Gen 9 running Ubuntu 2
 Using 100 characters allows two side-by-side files to be displayed with tmux, etc.
 
 ### Prefer single quotes
-This reduces visual noise. Black made the wrong choice; double-quote-fixer can help.
+Double quotes are visually noisier than single quotes. Black made the wrong choice; double-quote-fixer from pre-commit or `ruff format` can help.
 
 ## Settings
 ### Standard environment variables
@@ -20,6 +29,10 @@ This reduces visual noise. Black made the wrong choice; double-quote-fixer can h
 
 ### Begin as you mean to go on (people edition)
 Choose default values that will work, out-of-the-box, for most people, most of the time. Even if the machines outnumber the people, reconfiguring the development systems of people is probably harder than reconfiguring many hosted production and pre-production machines (pets versus cattle).
+
+### Single static assignment
+Try not to mutate variables, except in obvious ways like appending an element to a list for each iteration of a for loop.
+Prefer multiple, specific variable names over a general variable name with shifting values.
 
 ### Single static assignment
 Try not to mutate variables, except in obvious ways like appending an element to a list for each iteration of a for loop.
@@ -60,8 +73,9 @@ First, writing usernames and passwords into IaC or state files breaks the indivi
 1. Supply provider credentials via environment variables.
 2. Unless they're encrypted like aws_iam_user passwords, set passwords in resources to a placeholder
    value like `SEE-PASSWORD-MANAGER` and configure lifecycle ignore.
+3. Check git and state files to ensure secrets have not leaked into them.
 
-TODO patch OpenTofu to help with this. TODO find or develop a good approach to securely storing secrets from newly created resources, like `cloudflare_access_service_token`, and rotating secrets.
+TODO patch OpenTofu to help with this. TODO find or develop a good approach to 1. securely storing secrets from newly created resources, like `cloudflare_access_service_token`, and 2. rotating secrets.
 
 ## See Also
 * https://12factor.net/


### PR DESCRIPTION
### Background and Links
* A more detailed example of using Helicopyter is probably useful
* Working configuration should make Allowedflare easier to use

### Changes and Testing
* Continue writing style guidance
* Codify Cloudflare configuration: applied to prod

### Questions and Followup
* Better documentation, or even automation, of the fine-grained token permissions for Cloudflare
    - All accounts - Cloudflare Pages:Edit, Cloudflare Tunnel:Edit, Access: Organizations, Identity Providers, and Groups:Edit, Workers Scripts:Edit, Access: Apps and Policies:Edit
    - All zones - Health Checks:Edit, Workers Routes:Edit, DNS:Edit
* Okta Identity Provider example
* If we do a good enough job defining the elements of code simplicity/complexity, could we write a scorecard?