### PR TITLE
More pre-commit hooks

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -29,7 +29,7 @@ jobs:
                       ${{ hashFiles('requirements.txt') }}
                   restore-keys: ${{ runner.os }}-pip
 
-            - run: pip install --upgrade pip uv
+            - run: pip install --upgrade pip setuptools uv wheel
               env:
                   PIP_PROGRESS_BAR: 'off'
 
@@ -46,7 +46,7 @@ jobs:
                   key: ${{ steps.restore-uv.outputs.cache-primary-key }}
                   path: ~/.cache/uv
 
-            - run: source includes.sh && a && pre-commit-try-am
+            - run: source includes.sh && a && pre-commit-try-all
             - run: terraform -chdir=deploys/demo/terraform init
             - run: terraform -chdir=deploys/demo/terraform validate
 on: # yamllint disable-line rule:truthy

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,9 +1,27 @@
+- id: codespell
+  name: codespell
+  entry: codespell --check-filenames --ignore-words-list READYness
+  language: python
+  types:
+      - text
+
 - id: dot-yaml
   description: Require four letter suffix http://www.yaml.org/faq.html
   entry: dot-yaml
   files: .*\.yml$
   language: fail
   name: dot-yaml
+
+- id: gitignore-node-python
+  entry: >
+      bash -c 'langs={Node,Python};
+      curl -s https://raw.githubusercontent.com/github/gitignore/main/$langs.gitignore >
+      .gitignore'
+  language: system
+  name: gitignore-node-python
+  pass_filenames: false
+  stages:
+      - manual
 
 - id: gitignore-node-python-terraform
   entry: >
@@ -13,6 +31,23 @@
   language: system
   name: gitignore-node-python-terraform
   pass_filenames: false
+  stages:
+      - manual
+
+- id: hadolint
+  entry: hadolint
+  language: system
+  name: hadolint
+  types:
+      - dockerfile
+
+- id: includes-sh
+  entry: curl -Os https://raw.githubusercontent.com/covracer/helicopyter/main/includes.sh
+  language: system
+  name: includes-sh
+  pass_filenames: false
+  stages:
+      - manual
 
 - id: helicopyter-all
   entry: python -m helicopyter all

--- a/requirements.in
+++ b/requirements.in
@@ -1,16 +1,20 @@
-# Build time
-cdktf-cdktf-provider-cloudflare
-cdktf-cdktf-provider-null
-ipython
+# pre-commit Hooks
+codespell
+git+https://github.com/AleksaC/hadolint-py.git
 mypy
 pre-commit
-pytest
 ruff
 shellcheck-py
-twine
 uv
 validate-pyproject[all]
 yamllint
+
+# Build-Time (Not Part of pre-commit)
+cdktf-cdktf-provider-cloudflare
+cdktf-cdktf-provider-null
+ipython
+pytest
+twine
 
 # Runtime
 # TODO figure out how to install these from pyproject.toml

--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ yamllint
 cdktf-cdktf-provider-cloudflare
 cdktf-cdktf-provider-null
 ipython
-pytest
+pytest>=8  # Pin to keep recent
 twine
 
 # Runtime

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 # pre-commit Hooks
-codespell
+codespell>=2.3  # For codespell inline ignore comment support
 git+https://github.com/AleksaC/hadolint-py.git
 mypy
 pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ cfgv==3.4.0
     # via pre-commit
 charset-normalizer==3.3.2
     # via requests
+codespell==2.3.0
 constructs==10.3.0
     # via
     #   cdktf
@@ -43,6 +44,7 @@ fastjsonschema==2.19.1
     # via validate-pyproject
 filelock==3.13.1
     # via virtualenv
+hadolint-py @ git+https://github.com/AleksaC/hadolint-py.git@a54e4d51787678062c8e108b20782f00e707a40e
 identify==2.5.33
     # via pre-commit
 idna==3.6


### PR DESCRIPTION
## Changes
* Add Hadolint and Codespell linters/autoformatters
* Add auto-downloaders for includes.sh and NodeJS + Python .gitignore
* Iterate on shell functions

### Followup
* Write a Dockerfile for running Python and NodeJS, with debug tools like bind9-host
* Write a Dockerfile for running Ansible
* Write a Dockerfile for running Terraform
* Write a docker-compose.yaml for all of the above
* Make include.sh work equally well in a Docker container (for speed, probably with apt-packaged Python, NodeJS, etc.) as outside of it; or should we just drop host-side support?