### PR TITLE
Fix package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,0 @@
-exclude .*
-exclude deploys/demo/terraform/*
-exclude requirements*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,10 @@ split-on-trailing-comma = false
 [tool.ruff.lint.pydocstyle]
 convention = 'pep257'
 
-[tool.setuptools.packages]
-find = { namespaces = false }
+[tool.setuptools]
+py-modules = ['helicopyter']
+
+[tool.setuptools.packages.find]
+exclude = ['deploys*']
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,6 @@ convention = 'pep257'
 py-modules = ['helicopyter']
 
 [tool.setuptools.packages.find]
-exclude = ['deploys*']  # Applies to wheel but not sdist
+exclude = ['deploys*'] # Applies to wheel but not sdist
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,6 @@ convention = 'pep257'
 py-modules = ['helicopyter']
 
 [tool.setuptools.packages.find]
-exclude = ['deploys*']
+exclude = ['deploys*']  # Applies to wheel but not sdist
 
 [tool.setuptools_scm]


### PR DESCRIPTION
### Background and Links
* helicopyter.py was being left out of the wheel

### Changes and Testing
```
rm -r build dist; python -m build --wheel >/dev/null; unzip -l dist/*.whl
Archive:  dist/helicopyter-2024.27.3.dev1+g5aaf25b-py3-none-any.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
     5739  2024-07-19 11:51   helicopyter.py
    11586  2024-07-19 11:51   documentation/self2024-python-defined-infrastructure.md
    16725  2024-07-19 13:06   helicopyter-2024.27.3.dev1+g5aaf25b.dist-info/LICENSE
     2452  2024-07-19 13:06   helicopyter-2024.27.3.dev1+g5aaf25b.dist-info/METADATA
       91  2024-07-19 13:06   helicopyter-2024.27.3.dev1+g5aaf25b.dist-info/WHEEL
       31  2024-07-19 13:06   helicopyter-2024.27.3.dev1+g5aaf25b.dist-info/top_level.txt
      681  2024-07-19 13:06   helicopyter-2024.27.3.dev1+g5aaf25b.dist-info/RECORD
---------                     -------
    37305                     7 files
```

### Questions and Followup
* Command to check sdist `rm -r build dist; python -m build --sdist >/dev/null; tar -tf dist/*.tar.gz`