### PR TITLE
Python 3.10 compatability

### DIFF
--- a/helicopyter.py
+++ b/helicopyter.py
@@ -98,7 +98,7 @@ class HeliStack(TerraformStack):
         element = Element(self.scopes(Element.__module__), id_, *args, **kwargs)
         if import_id:
             self.imports[
-                f'{Element.__module__.replace('cdktf_cdktf_provider_', '').replace('.', '_')}.{id_}'
+                f"{Element.__module__.replace('cdktf_cdktf_provider_', '').replace('.', '_')}.{id_}"
             ] = import_id
         return element
 


### PR DESCRIPTION
Avoid:
```
$ python -m helicopyter foundation
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 187, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/lib/python3.10/runpy.py", line 157, in _get_module_details
    code = loader.get_code(mod_name)
  File "<frozen importlib._bootstrap_external>", line 1017, in get_code
  File "<frozen importlib._bootstrap_external>", line 947, in source_to_code
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/ubuntu/test/.venv/lib/python3.10/site-packages/helicopyter.py", line 101
    f'{Element.__module__.replace('cdktf_cdktf_provider_', '').replace('.', '_')}.{id_}'
                                   ^^^^^^^^^^^^^^^^^^^^^
SyntaxError: f-string: unmatched '('
```