### PR TITLE
Melt special snowflakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,21 @@ Cloud Development Kit (CDK) and more like Terraform.
 Helicopyter uses [CDKTF](https://github.com/hashicorp/terraform-cdk) and is inspired by [Configerator](https://research.facebook.com/file/877841159827226/holistic-configuration-management-at-facebook.pdf), [Terraformpy](https://github.com/NerdWalletOSS/terraformpy), and [Terraform JSON configuration syntax](https://developer.hashicorp.com/terraform/language/syntax/json).
 
 ## What Helicopyter does (goals)
-- Fix the CDKTF naming mess. Meaningful names make review easy. Terraform's resource prefix style results in meaningful
-  names and aligns with "Namespaces are one honking great idea -- let's do more of those!" The AWS CDK style of
-  suffixing hashes generates difficult-to-review `terraform plan` output and ignores the existing namespaces.
-- Provide a directory structure that groups primarily by "codename" (could be called application, service) and secondarily by tool. For now it assumes f'deploys/{codename}/terraform'.
+- Fix the CDK style naming mess. Meaningful names make review easy. Terraform's resource prefix
+  style results in meaningful names and aligns with "Namespaces are one honking great idea -- let's do
+  more of those!" The AWS CDK style of suffixing hashes generates difficult-to-review `terraform plan`
+  output and ignores the existing namespaces.
+- Provide a `f'deploys/{cona}/terraform'` directory structure, grouping
+    * Primarily by "codename" (cona), probably synonymous with application, deployment, and service
+    * Secondarily by tool, such as `ansible`, `docker`, `terraform`, `python`
+- Enable hand-written Hashicorp Configuration Language (HCL) files and auto-generated HCL/JSON to
+  co-exist, allowing incremental adoption.
+- Golang Terraform has a pretty good command line interface. The `ht[aip]` functions in
+  `includes.sh` try to wrap it very lightly.
 
 ## What Helicopyter will probably never do (non-goals)
-- Terraform has a pretty good command line interface. Helicopyter focuses on generating JSON for it. Helicopyter does
-  not try to wrap the `terraform` command line interface itself and using CDKTF's wrapper is untested and not
-  recommended.
+- Support languages other than Python
+- Make use of the CDKTF's command line interface. Integration with it is untested and not recommended.
 
 ## What Helicopyter might do in the future
 - Support multiple backend configurations per codename
@@ -25,3 +31,4 @@ Helicopyter uses [CDKTF](https://github.com/hashicorp/terraform-cdk) and is insp
 - `__str__()` for `to_string()`, etc.
 - Why do we need a Node.js server? Can we build dataclasses or Pydantic models out of the type annotations already being
   generated?
+- Provide helper classes or functions for useful but annoyingly verbose patterns such as local-exec provisioner command

--- a/deploys/buddies/terraform/main.tf.json
+++ b/deploys/buddies/terraform/main.tf.json
@@ -18,7 +18,7 @@
             "christopher_covington": {
                 "//": {
                     "metadata": {
-                        "path": "buddies/cdktf_cdktf_provider_github.membership/christopher_covington",
+                        "path": "buddies/github_membership/christopher_covington",
                         "uniqueId": "christopher_covington"
                     }
                 },
@@ -28,7 +28,7 @@
             "darren_pham": {
                 "//": {
                     "metadata": {
-                        "path": "buddies/cdktf_cdktf_provider_github.membership/darren_pham",
+                        "path": "buddies/github_membership/darren_pham",
                         "uniqueId": "darren_pham"
                     }
                 },
@@ -38,7 +38,7 @@
             "duncan_tormey": {
                 "//": {
                     "metadata": {
-                        "path": "buddies/cdktf_cdktf_provider_github.membership/duncan_tormey",
+                        "path": "buddies/github_membership/duncan_tormey",
                         "uniqueId": "duncan_tormey"
                     }
                 },
@@ -48,7 +48,7 @@
             "james_braza": {
                 "//": {
                     "metadata": {
-                        "path": "buddies/cdktf_cdktf_provider_github.membership/james_braza",
+                        "path": "buddies/github_membership/james_braza",
                         "uniqueId": "james_braza"
                     }
                 },
@@ -58,7 +58,7 @@
             "matt_fowler": {
                 "//": {
                     "metadata": {
-                        "path": "buddies/cdktf_cdktf_provider_github.membership/matt_fowler",
+                        "path": "buddies/github_membership/matt_fowler",
                         "uniqueId": "matt_fowler"
                     }
                 },

--- a/deploys/demo/terraform/main.py
+++ b/deploys/demo/terraform/main.py
@@ -1,6 +1,7 @@
 """Demonstrate a simple HeliStack synth function using CDKTF constructs."""
 
-from cdktf import LocalExecProvisioner
+from cdktf import LocalExecProvisioner, TerraformLocal, TerraformOutput, TerraformVariable
+from cdktf_cdktf_provider_null.resource import Resource as NullResource
 
 from helicopyter import HeliStack
 
@@ -11,18 +12,17 @@ def synth(stack: HeliStack) -> None:
 
     Also infer the ENVIronment (ENVI) from the workspace and echo it to standard output.
     """
-    NullResource = stack.load('null_resource')  # noqa: N806
+    stack.push(TerraformLocal, 'cona', stack.cona)
+    stack.push(TerraformLocal, 'envi', '${terraform.workspace}')
 
-    stack.Local('cona', stack.cona)
-    stack.Local('envi', '${terraform.workspace}')
-
-    NullResource(
-        'main',
+    stack.push(
+        NullResource,
+        'this',
         provisioners=[
             LocalExecProvisioner(
                 command='echo $envi', environment={'envi': '${local.envi}'}, type='local-exec'
             )
         ],
     )
-    gash = stack.Variable('gash', type='string')
-    stack.Output('gash', value=gash.to_string())
+    gash = stack.push(TerraformVariable, 'gash', type='string')
+    stack.push(TerraformOutput, 'gash', value=gash.to_string())

--- a/deploys/demo/terraform/main.tf.json
+++ b/deploys/demo/terraform/main.tf.json
@@ -25,11 +25,11 @@
     },
     "resource": {
         "null_resource": {
-            "main": {
+            "this": {
                 "//": {
                     "metadata": {
-                        "path": "demo/cdktf_cdktf_provider_null.resource/main",
-                        "uniqueId": "main"
+                        "path": "demo/null_resource/this",
+                        "uniqueId": "this"
                     }
                 },
                 "provisioner": [

--- a/deploys/foundation/terraform/main.tf.json
+++ b/deploys/foundation/terraform/main.tf.json
@@ -32,7 +32,7 @@
             "airdjang": {
                 "//": {
                     "metadata": {
-                        "path": "foundation/cdktf_cdktf_provider_github.repository/airdjang",
+                        "path": "foundation/github_repository/airdjang",
                         "uniqueId": "airdjang"
                     }
                 },
@@ -61,7 +61,7 @@
             "allowedflare": {
                 "//": {
                     "metadata": {
-                        "path": "foundation/cdktf_cdktf_provider_github.repository/allowedflare",
+                        "path": "foundation/github_repository/allowedflare",
                         "uniqueId": "allowedflare"
                     }
                 },
@@ -89,7 +89,7 @@
             "helicopyter": {
                 "//": {
                     "metadata": {
-                        "path": "foundation/cdktf_cdktf_provider_github.repository/helicopyter",
+                        "path": "foundation/github_repository/helicopyter",
                         "uniqueId": "helicopyter"
                     }
                 },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ ignore = [
     'EM102',
     'INP001',
     'ISC001',
+    'PT013',  # `import pytest` would be inconsistent with other imports
     'Q000',   # ruff format will single quote
     'Q001',   # ruff format will single quote
     'Q003',   # ruff format will single quote


### PR DESCRIPTION
### Background and Links
* The `load()` method was an interesting experiment but I expect `push()` to be the real workhorse for now
* I recently came to suspect that locals, variables, and outputs could be scoped very similarly to everything else

### Changes and Testing
* Add some unit tests
* Remove `HeliStack.load()`, `HeliStack.Local()`, `HeliStack.Output()`, and `HeliStack.Variable()`
* Make `HeliStack.push()` work for `TerraformLocal`, `TerraformOutput`, and `TerraformVariable`
* Name the scoping Constructs like provider documentation and plan and apply output