### PR TITLE
Current directory and change directory argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,4 @@ Helicopyter uses [CDKTF](https://github.com/hashicorp/terraform-cdk) and is insp
 - Why do we need a Node.js server? Can we build dataclasses or Pydantic models out of the type annotations already being
   generated?
 - Provide helper classes or functions for useful but annoyingly verbose patterns such as local-exec provisioner command
+- Backend / state file linter: prod must exist, and region/bucket/workspace_key_prefix/key must follow pattern

--- a/helicopyter.py
+++ b/helicopyter.py
@@ -75,13 +75,16 @@ class HeliStack(TerraformStack):
 
 # ruff: noqa: T201
 def multisynth(
-    all_or_conas_or_paths: Iterable[str], *, hashicorp_configuration_language: bool = False
+    all_or_conas_or_paths: Iterable[str],
+    *,
+    change_directory: Path | None = None,
+    hashicorp_configuration_language: bool = False,
 ) -> None:
     if not all_or_conas_or_paths:
         print('No codenames specified. Doing nothing.')
         return
 
-    top_directory = Path(__file__).parent
+    top_directory = change_directory if change_directory else Path.cwd()
 
     if 'all' in all_or_conas_or_paths or 'helicopyter.py' in all_or_conas_or_paths:
         conas_or_paths = {
@@ -135,12 +138,18 @@ def multisynth(
 
 class Parameters(Tap):
     conas: list[str]  # space-separated COdeNAmes
+    directory: Path | None = None
     hashicorp_configuration_language: bool = False
 
     def configure(self) -> None:  # noqa: D102
-        self.add_argument('conas')  # Make this a positional argument
+        self.add_argument('conas')  # Positional argument
+        self.add_argument('-C', '--directory')  # Like make and tar
 
 
 if __name__ == '__main__':
     args = Parameters().parse_args()
-    multisynth(args.conas, hashicorp_configuration_language=args.hashicorp_configuration_language)
+    multisynth(
+        args.conas,
+        change_directory=args.directory,
+        hashicorp_configuration_language=args.hashicorp_configuration_language,
+    )

--- a/includes.sh
+++ b/includes.sh
@@ -349,6 +349,17 @@ pctam() {
         "$@"
 }
 
+release() {
+    local prefix
+    prefix=$(date -u "+v${INSH_RELEASE_PREFIX:-%Y.%U.}")
+    git fetch --tags
+    local count
+    count=$(git tag --list "$prefix*" | gsed "s/$prefix//" | sort -r | head -1)
+    gh release create "$prefix$((${count:-0} + 1))" --generate-notes
+    git fetch --tags
+    [[ $* == build ]] && build_twine
+}
+
 summarize() {
     : 'SUMMARIZE for github actions'
     local CONA GASH TABR


### PR DESCRIPTION
### Background and Links
* Using the file's directory doesn't work very well when it's in the venv

### Changes and Testing
* Change the default directory to the current working directory
* Allow the directory to be overridden on the command line
* Add a release helper function

### Questions and Followup
* Using the file's directory might be hand for an includes.sh that's pip installed instead of installed via pre-commit hook
* Auto-discovering repository-specific build steps like `docker compose build` and `python -m build`
* Auto-discovering repository-specific release steps like `docker compose push` and `twine upload`
* Document `$INSH_RELEASE_PREFIX` and provide a general alternative to yucount and gvcount which uses it, or find a better way for people to choose their week-of-the-year numbering scheme