### PR TITLE
Fix cookiecutter hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -17,7 +17,7 @@
       - text
 
 - id: cookiecutter
-  entry: |
+  entry: >
       cookiecutter --config-file .cookiecutter.yaml --no-input --overwrite-if-exists \
       https://github.com/biobuddies/helicopyter.git
   language: system


### PR DESCRIPTION
Fix (note newline after double quote):
```
A valid repository for "
https://github.com/biobuddies/helicopyter.git" could not be found in the following locations
```