### PR TITLE
Fix cookiecutter hook again

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -18,7 +18,7 @@
 
 - id: cookiecutter
   entry: >
-      cookiecutter --config-file .cookiecutter.yaml --no-input --overwrite-if-exists \
+      cookiecutter --config-file .cookiecutter.yaml --no-input --overwrite-if-exists\
       https://github.com/biobuddies/helicopyter.git
   language: system
   name: cookiecutter


### PR DESCRIPTION
Fix
```
A valid repository for " https://github.com/biobuddies/helicopyter.git" could not be found in the following locations
```