### PR TITLE
PyPI compatibility

### DIFF
--- a/pypi_compatible_build.py
+++ b/pypi_compatible_build.py
@@ -1,0 +1,30 @@
+"""
+Avoid git URLs breaking PyPI uploads.
+
+Similar problem to:
+https://stackoverflow.com/questions/54887301/how-can-i-use-git-repos-as-dependencies-for-my-pypi-package
+"""
+
+from io import StringIO
+from typing import TextIO
+
+import setuptools
+from packaging.metadata import Metadata
+from setuptools._core_metadata import _write_requirements  # type: ignore[import-not-found]
+from setuptools.build_meta import *  # noqa: F403
+
+
+def write_pypi_compatible_requirements(self: Metadata, final_file: TextIO) -> None:
+    """Mark requirements with URLs as external."""
+    initial_file = StringIO()
+    _write_requirements(self, initial_file)
+    initial_file.seek(0)
+    for initial_line in initial_file:
+        final_line = initial_line
+        metadata = Metadata.from_email(initial_line, validate=False)
+        if metadata.requires_dist and metadata.requires_dist[0].url:
+            final_line = initial_line.replace('Requires-Dist:', 'Requires-External:')
+        final_file.write(final_line)
+
+
+setuptools._core_metadata._write_requirements = write_pypi_compatible_requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = ['setuptools>=61.0', 'setuptools_scm[toml]>=6.2', 'wheel']
-build-backend = 'setuptools.build_meta'
+build-backend = 'pypi_compatible_build'
+backend-path = ['']
 
 [project]
 classifiers = [
@@ -39,6 +40,7 @@ precommit = [
     'rust-just',
     'shellcheck-py',
     'shfmt-py',
+    'types-setuptools',
     'uv',
     'validate-pyproject[all]',
     'yamllint',
@@ -74,6 +76,7 @@ ignore = [
     'Q003',   # ruff format will single quote
     # N806 tries to lowercase classes; currently ignored on a line-by-line basis
     'S607',   # Using $PATH is pretty necessary for nvmrc, pyenv, venv, tfenv
+    'SLF001', # Private member access is probably a last resort
     'TD002',  # The git log records who wrote a TODO line
     'TD003',  # Don't require issue links
     'TD004',  # A colon takes up space without really improving readability

--- a/requirements.txt
+++ b/requirements.txt
@@ -258,6 +258,8 @@ typeguard==2.13.3
     #   jsii
 types-python-dateutil==2.9.0.20241206
     # via arrow
+types-setuptools==75.8.0.20250210
+    # via helicopyter (pyproject.toml)
 typing-extensions==4.12.2
     # via
     #   jsii


### PR DESCRIPTION
### Background and Links
* Hit the following error after moving requirements.txt into pyproject.toml as encouraged by https://realpython.com/python-pyproject-toml/#managing-dependencies-with-a-pyprojecttoml-file and other sources
```
400 Can't have direct dependency: hadolint-py@ git+https://github.com/AleksaC/hadolint-py.git ; extra ==
         "precommit". See https://packaging.python.org/specifications/core-metadata for more information.
           The server could not comply with the request since it is either malformed or otherwise incorrect.
```
- https://peps.python.org/pep-0517/#source-trees
- https://packaging.python.org/en/latest/specifications/core-metadata/#requires-external-multiple-use
- _write_requirements in setuptools that outputs Requires-Dist lines https://github.com/pypa/setuptools/blob/ba243756233d0afe944db6e02ddcb70064dcd22c/setuptools/_core_metadata.py#L222-L239
- PyPI code that checks Requires-Dist lines https://github.com/pypi/warehouse/blob/0b6c75a322e0d611b1b2cc6c065e0f7e25ba2580/warehouse/forklift/metadata.py#L256-L269
- https://stackoverflow.com/questions/54887301/how-can-i-use-git-repos-as-dependencies-for-my-pypi-package seems like the closest StackOverflow question

### Changes and Testing
* Put `Requires-External` instead of `Requires-Dist` in PKG-INFO when a URL is present

### Questions and Followup
* Should a version of this go into setuptools?